### PR TITLE
alterado o nome do id para id_endereco

### DIFF
--- a/BackEnd/src/main/java/com/indentados/clinicaodonto/model/Pessoa.java
+++ b/BackEnd/src/main/java/com/indentados/clinicaodonto/model/Pessoa.java
@@ -24,7 +24,7 @@ public class Pessoa {
     public String sobrenome;
 
     @OneToOne
-    @JoinColumn(name = "id")
+    @JoinColumn(name = "id_endereco")
     public Endereco endereco;
 
     @Column


### PR DESCRIPTION
A classe pessoa eu alterei o id do endereço para id_endereco pois o nome id estava igual da classe pessoa então o Hibernate não criavam as ligações estrageiras da tabela endereço com as tabelas paciente e dentista. agora esta criando.
Hibernate: alter table dentista add constraint FKb986jh3twekta40gbtgo6yviw foreign key (id_endereco) references endereco
Hibernate: alter table paciente add constraint FKfy8x7lraufk39i612qp19lq02 foreign key (id_endereco) references endereco